### PR TITLE
Use node-watch instead of fs.watch

### DIFF
--- a/bin/myth
+++ b/bin/myth
@@ -2,6 +2,7 @@
 
 var colors = require('colors');
 var fs = require('fs');
+var watchfs = require('node-watch');
 var myth = require('..');
 var program = require('commander');
 var read = require('read-file-stdin');
@@ -61,7 +62,7 @@ var watch = program.watch && input && output;
  */
 
 run();
-if (watch) fs.watch(input, run);
+if (watch) watchfs(input, run);
 
 /**
  * Run for the given input and output.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "rework-color-function": "0.0.3",
     "colors": "~0.6.2",
     "write-file-stdout": "0.0.2",
-    "read-file-stdin": "0.0.3"
+    "read-file-stdin": "0.0.3",
+    "node-watch": "0.3.4"
   },
   "devDependencies": {
     "mocha": "~1.15.1"


### PR DESCRIPTION
fs.watch caused problems when text editors output temporary files.
This commit changes the myth executable to use node-watch rather than
fs.watch, allowing myth to honor the --watch flag when the file is
edited with a text editor that outputs temporary files (e.g. Vim).

Fixes #22
