### PR TITLE
#16 Passing options to autoprefixer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 
 var color = require('rework-color-function');
-var prefixes = require('autoprefixer')().rework;
+var prefixes = require('autoprefixer');
 var rework = require('rework');
 var calc = require('rework-calc');
 var variants = require('rework-font-variant');
@@ -22,9 +22,22 @@ module.exports = myth;
  */
 
 function myth (string, options) {
-  if ('string' != typeof string) return plugin;
+  /* autoprefix default options */
+  var browsers = ['> 1%', 'last 2 versions', 'ff 24', 'opera 12.1'];
+  if(options && options.browsers) {
+    browsers = options.browsers;
+  }
+
+  if ('string' != typeof string) {
+    return plugin.bind(this);
+  }
   return rework(string, options)
-    .use(plugin)
+    .use(vars)
+    .use(hex)
+    .use(color)
+    .use(calc)
+    .use(variants)
+    .use(prefixes(browsers).rework)
     .toString(options);
 }
 
@@ -42,5 +55,5 @@ function plugin (stylesheet, rework) {
     .use(color)
     .use(calc)
     .use(variants)
-    .use(prefixes);
+    .use(prefixes(browsers).rework);
 }

--- a/test/features/prefixes_ff24.out.css
+++ b/test/features/prefixes_ff24.out.css
@@ -1,0 +1,3 @@
+body {
+  transition: transform 1s;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -24,11 +24,11 @@ var features = [
 
 describe('myth', function () {
   it('should return a css string', function () {
-    assert('string' == typeof myth('body {}'));
+    assert('string' === typeof myth('body {}'));
   });
 
   it('should return a rework plugin', function () {
-    assert('function' == typeof myth());
+    assert('function' === typeof myth());
   });
 });
 
@@ -43,6 +43,19 @@ describe('features', function () {
       var output = read('features/' + name + '.out');
       assert.equal(myth(input).trim(), output.trim());
     });
+  });
+});
+
+/**
+ * Rework autoprefix browsers option tests.
+ */
+
+describe('autoprefix browser options', function () {
+  it('Firefox 28 only version should not add webkit- support', function () {
+    var input = read('features/prefixes');
+    var output = read('features/prefixes_ff24.out');
+    assert.equal(myth(input, {browsers: ['ff 24']}).trim(),
+      output.trim());
   });
 });
 
@@ -103,7 +116,7 @@ describe('cli', function () {
   it('should log on verbose', function (done) {
     exec('bin/myth -v test/cli/input.css test/cli/output.css', function (err, stdout) {
       if (err) return done(err);
-      assert(-1 != stdout.indexOf('write'));
+      assert(-1 !== stdout.indexOf('write'));
       done();
     });
   });
@@ -111,8 +124,8 @@ describe('cli', function () {
   it('should log on non-existant file', function (done) {
     exec('bin/myth test/cli/non-existant.css', function (err, stdout, stderr) {
       assert(err);
-      assert(err.code == 1);
-      assert(-1 != stderr.indexOf('not found'));
+      assert(err.code === 1);
+      assert(-1 !== stderr.indexOf('not found'));
       done();
     });
   });
@@ -120,12 +133,12 @@ describe('cli', function () {
   it('should print a nice error', function (done) {
     exec('bin/myth test/cli/error.css', function (err, stdout, stderr) {
       assert(err);
-      assert(err.code == 1);
-      assert(-1 != stderr.indexOf('error'));
-      assert(-1 != stderr.indexOf('SyntaxError: Missing closing parentheses'));
-      assert(-1 != stderr.indexOf('at '));
-      assert(-1 != stderr.indexOf('248'));
-      assert(-1 != stderr.indexOf('color('));
+      assert(err.code === 1);
+      assert(-1 !== stderr.indexOf('error'));
+      assert(-1 !== stderr.indexOf('SyntaxError: Missing closing parentheses'));
+      assert(-1 !== stderr.indexOf('at '));
+      assert(-1 !== stderr.indexOf('248'));
+      assert(-1 !== stderr.indexOf('color('));
       done();
     });
   });


### PR DESCRIPTION
patch for issue #16

Not change current syntax, so user could pass browsers list in {}

```
myth(css, { 
  browsers: ['ff 28']
});
```

test case included
