### PR TITLE
Switch from `rework-inline` to `rework-import`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ var calc = require('rework-calc');
 var color = require('rework-color-function');
 var dirname = require('path').dirname;
 var hex = require('rework-hex-alpha');
-var inline = require('rework-inline');
+var importer = require('rework-import');
 var noop = function(){};
 var rework = require('rework');
 var variants = require('rework-font-variant');
@@ -56,7 +56,7 @@ function plugin(options){
       : autoprefixer(browsers).rework;
 
     var imports = 'undefined' == typeof window && source
-      ? inline({ path: dirname(source) })
+      ? importer({ path: dirname(source) })
       : noop;
 
     rework

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "rework-hex-alpha": "^1.0.0",
     "rework-vars": "3.0.0",
     "write-file-stdout": "0.0.2",
-    "rework-inline": "~0.2.0",
+    "rework-import": "^1.0.0",
     "is-browser": "~2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Like said in https://github.com/segmentio/myth/issues/62#issuecomment-45575950 , [rework-inline](https://github.com/kevva/rework-inline) has been merged into [rework-import](https://github.com/reworkcss/rework-import) (moved under the rework org).

This will bring the followings:
- better error reporting (source when it’s possible (nested imports), with array of paths where it’s trying to load the file from)
- local (relative) files (`@import “./stuff“` now try first a relative import)
- `@import url()` syntax support
- ignore http like url (all protocol based url `://`).
