### PR TITLE
Pass actual browsers array to autoprefixer

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -117,7 +117,7 @@ exports.prefixes = function(options){
   var opts = clone(options);
   var src = options.source;
   var prefixes = options.browsers
-    ? autoprefixer(browsers)
+    ? autoprefixer(options.browsers)
     : autoprefixer();
 
   return function(stylesheet, rework){


### PR DESCRIPTION
Previously, myth would die if the `browsers` option was used, because it was passing an undefined variable to autoprefixer instead of `options.browsers`. This fixes that.
