### PR TITLE
Fixed bug where options isn't passed to variables

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -33,7 +33,7 @@ exports.import = function(options){
  */
 
 exports.variables = function(options){
-  return variables;
+  return variables(options);
 };
 
 /**

--- a/lib/features.js
+++ b/lib/features.js
@@ -33,7 +33,7 @@ exports.import = function(options){
  */
 
 exports.variables = function(options){
-  return variables();
+  return variables;
 };
 
 /**


### PR DESCRIPTION
I'm not sure if you'd like the options to be namespaced by feature (so in the pull request it'll be `options.variables` instead).
Let me know if you want the same to be done for the other plugins.